### PR TITLE
Add `climit` include, required to build on Ubuntu 22.04

### DIFF
--- a/src/vobsub2srt.c++
+++ b/src/vobsub2srt.c++
@@ -30,6 +30,7 @@
 #include <string>
 #include <cstdio>
 #include <vector>
+#include <climits>
 using namespace std;
 
 #include "langcodes.h++"


### PR DESCRIPTION
Required in order to compile on Ubuntu 22.04; presumably on modern Debian-based systems.